### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Form.pm
+++ b/lib/Form.pm
@@ -1,4 +1,4 @@
-module Form;
+unit module Form;
 
 use Form::TextFormatting;
 use Form::Grammar;

--- a/lib/Form/Field.pm
+++ b/lib/Form/Field.pm
@@ -1,4 +1,4 @@
-module Form::Field;
+unit module Form::Field;
 
 use Form::TextFormatting;
 use Form::NumberFormatting;

--- a/lib/Form/NumberFormatting.pm
+++ b/lib/Form/NumberFormatting.pm
@@ -1,4 +1,4 @@
-module Form::NumberFormatting;
+unit module Form::NumberFormatting;
 
 use Form::TextFormatting;
 

--- a/lib/Form/TextFormatting.pm
+++ b/lib/Form/TextFormatting.pm
@@ -1,4 +1,4 @@
-module Form::TextFormatting;
+unit module Form::TextFormatting;
 
 =begin pod
 

--- a/lib/Form/Types.pm
+++ b/lib/Form/Types.pm
@@ -1,4 +1,4 @@
-module Form::Types;
+unit module Form::Types;
 
 enum Justify is export <left right centre full>;
 enum Alignment is export <top middle bottom>;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.