### PR TITLE
Fixed compilation errors caused by wrong number of arguments

### DIFF
--- a/lib/Form.pm
+++ b/lib/Form.pm
@@ -39,7 +39,7 @@ sub form(*@args --> Str) is export {
 		my $most-lines = ([max] @formatted.map: *.elems);
 		# RAKUDO: used to use $flines is rw and just overwrite in place that way
 		# But it doesn't seem to work at the moment
-		for @($f.ast) Z (0..*) -> $field, $index {
+		for (@($f.ast) Z (0..*)) -> ($field, $index) {
 			if @formatted[$index].elems < $most-lines {
 				if $field ~~ Form::Field::Field {
 					@formatted[$index] = $field.align(@formatted[$index], $most-lines);

--- a/t/02-fieldobjects.t
+++ b/t/02-fieldobjects.t
@@ -6,7 +6,7 @@ plan 6;
 use Form::Field;
 
 my $textfield;
-lives_ok(
+lives-ok(
 	{
 		$textfield = Form::Field::Text.new;
 	},
@@ -17,7 +17,7 @@ ok($textfield, "TextField constructor returned an object");
 
 {
     my $numeric-field;
-    lives_ok( { $numeric-field = Form::Field::Numeric.new; },
+    lives-ok( { $numeric-field = Form::Field::Numeric.new; },
               'NumericField constructs with no parameters'
     );
     ok($numeric-field.defined, 'NumericField constructor returned an object');
@@ -25,7 +25,7 @@ ok($textfield, "TextField constructor returned an object");
 
 {
 	my $verbatim-field;
-	lives_ok( { $verbatim-field = Form::Field::Verbatim.new; },
+	lives-ok( { $verbatim-field = Form::Field::Verbatim.new; },
 			'VerbatimField constructs with no parameters'
 	);
 	ok($verbatim-field.defined, 'VerbatimField constructor returns an onbject');

--- a/t/04-parseactions.t
+++ b/t/04-parseactions.t
@@ -56,7 +56,7 @@ ok($mixed-results.ast ~~ Array, "Mixed field parse returned an array");
 ok($mixed-results.ast.elems == 5, "Mixed field parse had the correct number of elements");
 
 my $c = 1;
-for $mixed-results.ast Z (Str, Form::Field::Text, Str, Form::Field::Text, Form::Field::Text) -> $r, $e {
+for $mixed-results.ast Z (Str, Form::Field::Text, Str, Form::Field::Text, Form::Field::Text) -> ($r, $e) {
 	ok($r ~~ $e, "Mixed field section {$c++} has type {$e.^name} ({$r.^name})");
 }
 

--- a/t/06-form.t
+++ b/t/06-form.t
@@ -16,7 +16,7 @@ ok(form(
     '|{<<}|', 'aa',
     '+----+'
 ) eq "+----+\n|aa  |\n+----+\n", "Two literals, one field");
-dies_ok(-> { form('{<<}{>>}', 'a') }, "Insufficient arguments");
+dies-ok(-> { form('{<<}{>>}', 'a') }, "Insufficient arguments");
 ok(form('{<<<<<}', "The quick brown fox jumps over the lazy dog") eq "The    \n", "Line field overflow");
 # TODO: reformat these as here-documents for neatness - when Rakudo supports them
 ok(form('{[[[[[}', "The quick brown fox jumps over the lazy dog") eq "The    \nquick  \nbrown  \nfox    \njumps  \nover   \nthe    \nlazy   \ndog    \n", "Block field overflow");
@@ -31,7 +31,7 @@ ok(
 );
 ok(form('{""}', "Boo\nYah") eq "Boo \nYah \n", "Literal block field");
 
-dies_ok({form('{<<<<}')}, 'Too few arguments');
+dies-ok({form('{<<<<}')}, 'Too few arguments');
 
 # time for some numbers
 


### PR DESCRIPTION
Changed dies_ok, lives_ok with non-depreacated equivalends

Done in minefield technique (without any understanding of why this things require changes)

Tests still fail but at least compile and don't break my project