### PR TITLE
Fixed test justification to pass tests with some refactoring

### DIFF
--- a/lib/Form/TextFormatting.pm
+++ b/lib/Form/TextFormatting.pm
@@ -109,9 +109,8 @@ our sub full-justify(Str $line, Int $width, Str $space = ' ') {
 	# for now, do something entirely unsatisfactory
 	if $line.chars < $width {
 		my Str @words = $line.words;
-		my $to-add = $width - $line.chars;
 		my $words = @words.elems;
-		my @spaces = $space xx ($words - 1);
+		my Str @spaces = $space xx ($words - 1);
 
 		my $words-width = [+] @words.map: *.chars;
 		my $spaces-width = [+] @spaces.map: *.chars;
@@ -119,16 +118,15 @@ our sub full-justify(Str $line, Int $width, Str $space = ' ') {
 		my $act-space = 0;
 		while $words-width + $spaces-width < $width
 		{
+
 			@spaces[$act-space++] ~= $space;
 
 			$spaces-width = [+] @spaces.map({ .chars });
-
-			$act-space >= @spaces.elems and $act-space = 0;
+			$act-space = 0 if $act-space == @spaces.elems;
 		}
-
-		@spaces.push('');
-
-		return (@words Z @spaces).join;
+               # We add empty elem to make zip operation work here
+               @spaces.push('');
+               return (@words Z~ @spaces).join;
 	}
 
 	return $line.substr(0, $width);

--- a/t/03-textformatting.t
+++ b/t/03-textformatting.t
@@ -42,10 +42,10 @@ ok(Form::TextFormatting::right-justify($str, 6) eq "  ABCD", "right-justify corr
 ok(Form::TextFormatting::centre-justify($str, 6) eq " ABCD ", "centre-justify correct");
 ok(Form::TextFormatting::centre-justify($str, 7) eq " ABCD  ", "uneven centre-justify correct");
 
-ok(Form::TextFormatting::full-justify($str, 6) eq "ABCD  ", "fully justify with one word correct");
-ok(Form::TextFormatting::full-justify("A B", 6) eq "A    B", "fully justify with two words correct");
-ok(Form::TextFormatting::full-justify("A B C", 9) eq "A   B   C", "fully justify with three words correct");
-ok(Form::TextFormatting::full-justify("A B C", 10) eq "A    B   C", "fully justify with three words uneven correct");
+is(Form::TextFormatting::full-justify($str, 6), "ABCD  ", "fully justify with one word correct");
+is(Form::TextFormatting::full-justify("A B", 6),  "A    B", "fully justify with two words correct");
+is(Form::TextFormatting::full-justify("A B C", 9), "A   B   C", "fully justify with three words correct");
+is(Form::TextFormatting::full-justify("A B C", 10), "A    B   C", "fully justify with three words uneven correct");
 
 # vim: ft=perl6 sw=4 ts=4 noexpandtab
 


### PR DESCRIPTION
* Changed Z operator to Z~ to make it not adding unwanted spaces.
* Applied some refactoring for example using is instead of ok gives
  more info whem test fails
* Statement modifier is more expressive than using precedence of and operator
* Removed unused variable